### PR TITLE
Add VP verification controller and improve configuration

### DIFF
--- a/src/main/java/com/mbi/vpverifier/controller/VpVerificationController.java
+++ b/src/main/java/com/mbi/vpverifier/controller/VpVerificationController.java
@@ -1,0 +1,48 @@
+package com.mbi.vpverifier.controller;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.client.RestTemplate;
+
+@RestController
+@RequestMapping("/verify")
+public class VpVerificationController {
+    
+    private static final Logger logger = LoggerFactory.getLogger(VpVerificationController.class);
+    
+    private final RestTemplate restTemplate;
+    
+    @Value("${provider.base-url}")
+    private String providerBaseUrl;
+    
+    public VpVerificationController(RestTemplate restTemplate) {
+        this.restTemplate = restTemplate;
+    }
+    
+    @GetMapping("/{vpId}")
+    public ResponseEntity<String> verifyVp(@PathVariable String vpId) {
+        try {
+            logger.info("Verifying VP with ID: {}", vpId);
+            
+            String providerUrl = providerBaseUrl + "/v1/vp/verify/" + vpId;
+            logger.debug("Calling provider URL: {}", providerUrl);
+            
+            // RestTemplate will automatically add Authorization header via TokenInterceptor
+            ResponseEntity<String> response = restTemplate.getForEntity(providerUrl, String.class);
+            
+            logger.info("VP verification completed for ID: {}", vpId);
+            return response;
+            
+        } catch (Exception e) {
+            logger.error("VP verification failed for ID: {}", vpId, e);
+            return ResponseEntity.internalServerError()
+                .body("VP verification failed: " + e.getMessage());
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,16 +15,20 @@ spring:
           max-idle: 8
           min-idle: 0
 
+# Provider Configuration
+provider:
+  base-url: http://localhost:43313
+
 # Token Configuration
 token:
   provider:
     # Client credentials (should be encrypted in production)
-    client-id: ${TOKEN_CLIENT_ID:your-client-id}
-    client-secret: ${TOKEN_CLIENT_SECRET:your-client-secret}
+    client-id: ${TOKEN_CLIENT_ID}
+    client-secret: ${TOKEN_CLIENT_SECRET}
     
     # Provider URLs
-    create-token-url: ${TOKEN_CREATE_URL:http://localhost:43313/v1/token/create}
-    refresh-token-url: ${TOKEN_REFRESH_URL:http://localhost:43313/v1/token/refresh}
+    create-token-url: ${provider.base-url}/v1/token/create
+    refresh-token-url: ${provider.base-url}/v1/token/refresh
     
     # Token management settings
     access-token-buffer-minutes: 2  # Refresh 2 minutes before expiry


### PR DESCRIPTION
- Create VpVerificationController for /verify/{vpId} endpoint
- Add provider.base-url configuration for centralized URL management
- Update token URLs to reference provider.base-url
- Remove default values from configuration properties for fail-fast behavior
- Controller makes GET request to provider /v1/vp/verify/{vpId} with automatic token authentication